### PR TITLE
Fallback to size 0 for remote resources

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
             "Phpro\\ResourceStream\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": { "Phpro\\ResourceStream\\Tests\\": "tests/" }
+    },
     "authors": [
         {
             "name": "Toon Verwerft",

--- a/src/ResourceStream.php
+++ b/src/ResourceStream.php
@@ -195,12 +195,12 @@ final class ResourceStream
     /**
      * @throws RuntimeException
      */
-    public function getContents(): string
+    public function getContents(?int $length = null, int $offset = -1): string
     {
         $resource = $this->unwrap();
 
         return SafeStreamAction::run(
-            static fn (): string|false => stream_get_contents($resource),
+            static fn (): string|false => stream_get_contents($resource, $length, $offset),
             'Failed to read contents of resource stream.'
         );
     }

--- a/src/ResourceStream.php
+++ b/src/ResourceStream.php
@@ -152,7 +152,7 @@ final class ResourceStream
         $target = $targetStream->unwrap();
 
         SafeStreamAction::run(
-            static fn (): int => stream_copy_to_stream($resource, $target, $length, $offset),
+            static fn (): int|false => stream_copy_to_stream($resource, $target, $length, $offset),
             'Failed to copy to resource stream.'
         );
 
@@ -172,7 +172,7 @@ final class ResourceStream
         $resource = $this->unwrap();
 
         SafeStreamAction::run(
-            static fn (): int => stream_copy_to_stream($source, $resource, $length, $offset),
+            static fn (): int|false => stream_copy_to_stream($source, $resource, $length, $offset),
             'Failed to copy from resource stream.'
         );
 
@@ -200,7 +200,7 @@ final class ResourceStream
         $resource = $this->unwrap();
 
         return SafeStreamAction::run(
-            static fn (): string => stream_get_contents($resource),
+            static fn (): string|false => stream_get_contents($resource),
             'Failed to read contents of resource stream.'
         );
     }
@@ -211,9 +211,12 @@ final class ResourceStream
     public function size(): int
     {
         $resource = $this->unwrap();
-        $stat = fstat($resource) ?: [];
+        $stat = SafeStreamAction::run(
+            static fn (): array|false => fstat($resource),
+            'Failed to fstat of resource stream.'
+        );
 
-        return $stat['size'] ?? 0;
+        return $stat['size'];
     }
 
     /**
@@ -224,7 +227,7 @@ final class ResourceStream
         $resource = $this->unwrap();
 
         return SafeStreamAction::run(
-            static fn (): string => fread($resource, $length),
+            static fn (): string|false => fread($resource, $length),
             'Failed to read contents of resource stream.'
         );
     }
@@ -237,7 +240,7 @@ final class ResourceStream
         $resource = $this->unwrap();
 
         return SafeStreamAction::run(
-            static fn (): string => stream_get_line($resource, $length, $ending),
+            static fn (): string|false => stream_get_line($resource, $length, $ending),
             'Failed to read contents of resource stream.'
         );
     }
@@ -276,7 +279,7 @@ final class ResourceStream
         $resource = $this->unwrap();
 
         SafeStreamAction::run(
-            static fn (): int => fwrite($resource, $data),
+            static fn (): int|false => fwrite($resource, $data),
             'Failed to write to resource stream.'
         );
 

--- a/src/ResourceStream.php
+++ b/src/ResourceStream.php
@@ -211,12 +211,9 @@ final class ResourceStream
     public function size(): int
     {
         $resource = $this->unwrap();
-        $stat = SafeStreamAction::run(
-            static fn (): array => fstat($resource),
-            'Failed to stat resource stream.'
-        );
+        $stat = fstat($resource) ?: [];
 
-        return (int) ($stat['size'] ?? 0);
+        return $stat['size'] ?? 0;
     }
 
     /**

--- a/tests/Unit/ErrorHandling/SafeStreamActionTest.php
+++ b/tests/Unit/ErrorHandling/SafeStreamActionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Unit\ErrorHandling;
+namespace Phpro\ResourceStream\Tests\Unit\ErrorHandling;
 
 use Phpro\ResourceStream\ErrorHandling\SafeStreamAction;
 use Phpro\ResourceStream\Exception\StreamActionFailureException;

--- a/tests/Unit/Exception/ResourceStreamExceptionTest.php
+++ b/tests/Unit/Exception/ResourceStreamExceptionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Unit\Exception;
+namespace Phpro\ResourceStream\Tests\Unit\Exception;
 
 use Phpro\ResourceStream\Exception\ResourceStreamException;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Exception/StreamActionFailureExceptionTest.php
+++ b/tests/Unit/Exception/StreamActionFailureExceptionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Unit\Exception;
+namespace Phpro\ResourceStream\Tests\Unit\Exception;
 
 use Phpro\ResourceStream\Exception\StreamActionFailureException;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Factory/CliStreamTest.php
+++ b/tests/Unit/Factory/CliStreamTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Unit\Factory;
+namespace Phpro\ResourceStream\Tests\Unit\Factory;
 
 use Phpro\ResourceStream\Factory\CliStream;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Factory/FileStreamTest.php
+++ b/tests/Unit/Factory/FileStreamTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Unit\Factory;
+namespace Phpro\ResourceStream\Tests\Unit\Factory;
 
 use Phpro\ResourceStream\Exception\ResourceStreamException;
 use Phpro\ResourceStream\Factory\FileStream;

--- a/tests/Unit/Factory/IOStreamTest.php
+++ b/tests/Unit/Factory/IOStreamTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Unit\Factory;
+namespace Phpro\ResourceStream\Tests\Unit\Factory;
 
 use Phpro\ResourceStream\Factory\IOStream;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Factory/MemoryStreamTest.php
+++ b/tests/Unit/Factory/MemoryStreamTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Unit\Factory;
+namespace Phpro\ResourceStream\Tests\Unit\Factory;
 
 use Phpro\ResourceStream\Factory\MemoryStream;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Factory/Psr7StreamTest.php
+++ b/tests/Unit/Factory/Psr7StreamTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Unit\Factory;
+namespace Phpro\ResourceStream\Tests\Unit\Factory;
 
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;

--- a/tests/Unit/Factory/TmpStreamTest.php
+++ b/tests/Unit/Factory/TmpStreamTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Unit\Factory;
+namespace Phpro\ResourceStream\Tests\Unit\Factory;
 
 use Phpro\ResourceStream\Factory\TmpStream;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/ResourceStreamTest.php
+++ b/tests/Unit/ResourceStreamTest.php
@@ -163,6 +163,14 @@ class ResourceStreamTest extends TestCase
     }
 
     #[Test]
+    public function it_do_not_now_size_if_fstat_failed(): void
+    {
+        $stream = new ResourceStream(fopen('https://www.google.com/', 'r'));
+
+        self::assertSame(0, $stream->size());
+    }
+
+    #[Test]
     public function it_knows_the_uri(): void
     {
         $stream = MemoryStream::create();

--- a/tests/Unit/ResourceStreamTest.php
+++ b/tests/Unit/ResourceStreamTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Phpro\ResourceStreamTest\Unit;
 
 use Phpro\ResourceStream\Exception\ResourceStreamException;
+use Phpro\ResourceStream\Exception\StreamActionFailureException;
 use Phpro\ResourceStream\Factory\MemoryStream;
 use Phpro\ResourceStream\ResourceStream;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -84,6 +85,17 @@ class ResourceStreamTest extends TestCase
     }
 
     #[Test]
+    public function it_throws_stream_action_exception_if_write_fails(): void
+    {
+        $stream = new ResourceStream(fopen('php://memory', 'r'));
+
+        $this->expectException(StreamActionFailureException::class);
+        $this->expectExceptionMessage('Failed to write to resource stream.');
+
+        $stream->write('hello');
+    }
+
+    #[Test]
     public function it_can_read_line_from_stream(): void
     {
         $stream = MemoryStream::create()
@@ -93,6 +105,17 @@ class ResourceStreamTest extends TestCase
         $line = $stream->readLine();
 
         self::assertSame('hello', $line);
+    }
+
+    #[Test]
+    public function it_throws_stream_action_exception_if_read_line_fails(): void
+    {
+        $stream = new ResourceStream(fopen('php://memory', 'w'));
+
+        $this->expectException(StreamActionFailureException::class);
+        $this->expectExceptionMessage('Failed to read contents of resource stream.');
+
+        $stream->readLine();
     }
 
     #[Test]
@@ -163,11 +186,13 @@ class ResourceStreamTest extends TestCase
     }
 
     #[Test]
-    public function it_do_not_now_size_if_fstat_failed(): void
+    public function it_throws_stream_action_exception_if_fstat_fails(): void
     {
         $stream = new ResourceStream(fopen('https://www.google.com/', 'r'));
+        $this->expectException(StreamActionFailureException::class);
+        $this->expectExceptionMessage('Failed to fstat of resource stream.');
 
-        self::assertSame(0, $stream->size());
+        $stream->size();
     }
 
     #[Test]
@@ -190,6 +215,18 @@ class ResourceStreamTest extends TestCase
     }
 
     #[Test]
+    public function it_throws_stream_action_exception_if_copy_from_fails(): void
+    {
+        $stream1 = new ResourceStream(fopen('php://memory', 'r'));
+        $stream2 = MemoryStream::create()->write('hello')->rewind();
+
+        $this->expectException(StreamActionFailureException::class);
+        $this->expectExceptionMessage('Failed to copy from resource stream.');
+
+        $stream1->copyFrom($stream2);
+    }
+
+    #[Test]
     public function it_can_copy_to(): void
     {
         $stream1 = MemoryStream::create();
@@ -198,6 +235,18 @@ class ResourceStreamTest extends TestCase
         $stream2->copyTo($stream1)->rewind();
 
         self::assertSame('hello', $stream1->getContents());
+    }
+
+    #[Test]
+    public function it_throws_stream_action_exception_if_copy_to_fails(): void
+    {
+        $stream1 = new ResourceStream(fopen('php://memory', 'r'));
+        $stream2 = MemoryStream::create()->write('hello')->rewind();
+
+        $this->expectException(StreamActionFailureException::class);
+        $this->expectExceptionMessage('Failed to copy to resource stream.');
+
+        $stream2->copyTo($stream1);
     }
 
     #[Test]

--- a/tests/Unit/ResourceStreamTest.php
+++ b/tests/Unit/ResourceStreamTest.php
@@ -220,7 +220,8 @@ class ResourceStreamTest extends TestCase
     #[Test]
     public function it_throws_stream_action_exception_if_fstat_fails(): void
     {
-        $stream = new ResourceStream(fopen('https://www.google.com/', 'r'));
+        $stream = new ResourceStream(fopen('fakefailing://', 'r'));
+
         $this->expectException(StreamActionFailureException::class);
         $this->expectExceptionMessage('Failed to fstat of resource stream.');
 

--- a/tests/fixtures/FakeFailingStream.php
+++ b/tests/fixtures/FakeFailingStream.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpro\ResourceStream\Tests\fixtures;
+
+class FakeFailingStream
+{
+    public function dir_closedir(): bool
+    {
+        return false;
+    }
+
+    public function dir_opendir(string $path, int $options): bool
+    {
+        return false;
+    }
+
+    public function dir_readdir(): string
+    {
+        return '';
+    }
+
+    public function dir_rewinddir(): bool
+    {
+        return false;
+    }
+
+    public function mkdir(string $path, int $mode, int $options): bool
+    {
+        return false;
+    }
+
+    public function rename(string $path_from, string $path_to): bool
+    {
+        return false;
+    }
+
+    public function rmdir(string $path, int $options): bool
+    {
+        return false;
+    }
+
+    public function stream_cast(int $cast_as): mixed
+    {
+        return false;
+    }
+
+    public function stream_close(): void
+    {
+    }
+
+    public function stream_eof(): bool
+    {
+        return false;
+    }
+
+    public function stream_flush(): bool
+    {
+        return false;
+    }
+
+    public function stream_lock(int $operation): bool
+    {
+        return false;
+    }
+
+    public function stream_metadata(string $path, int $option, mixed $value): bool
+    {
+        return false;
+    }
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$opened_path): bool
+    {
+        return true;
+    }
+
+    public function stream_read(int $count): string|false
+    {
+        return false;
+    }
+
+    public function stream_seek(int $offset, int $whence = SEEK_SET): bool
+    {
+        return false;
+    }
+
+    public function stream_set_option(int $option, int $arg1, int $arg2): bool
+    {
+        return false;
+    }
+
+    public function stream_stat(): array|false
+    {
+        return false;
+    }
+
+    public function stream_tell(): int
+    {
+        return 0;
+    }
+
+    public function stream_truncate(int $new_size): bool
+    {
+        return false;
+    }
+
+    public function stream_write(string $data): int
+    {
+        return 0;
+    }
+
+    public function unlink(string $path): bool
+    {
+        return false;
+    }
+
+    public function url_stat(string $path, int $flags): array|false
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
If the resource isn't a file pointer, it seems the `fstats` function can returns false. 
Then the application can run into following error:
```
Uncaught PHP Exception TypeError: "Phpro\ResourceStream\ResourceStream::Phpro\ResourceStream\{closure}(): Return value must be of type array, false returned" at ResourceStream.php line 215
``` 

According the [docs](https://www.php.net/manual/en/function.fstat.php): _Gathers the statistics of the file opened by the file pointer stream._ 

